### PR TITLE
Tasks with start and end date set to the next day are 'Delayed' by default

### DIFF
--- a/app/ninetwofive/task/TaskRepository.php
+++ b/app/ninetwofive/task/TaskRepository.php
@@ -127,7 +127,7 @@ class TaskRepository implements TaskInterface{
 						$today = new ExpressiveDate();
 						$enddate = new ExpressiveDate($task['end_date']);
 						$task['num_status'] =(int) $today->getDifferenceInDays($enddate);
-						if((int)$task['num_status'] <= 0)
+						if((int)$task['num_status'] < 0)
 						{
 							$tempTask = \Task::find($task['id']);
 							$tempTask->status = 'delayed';


### PR DESCRIPTION
Hello, I sent you this bug report: http://forums.92fiveapp.com/?p=50-tasks-with-start-and-end-date-set-to-the-next-day-are-marked-as, and this is the pull request that I mentioned.

Thank you.
