### PR TITLE
Fixing issue of NOT NULL field 'updated_by' not being set for new projec...

### DIFF
--- a/app/ninetwofive/project/ProjectRepository.php
+++ b/app/ninetwofive/project/ProjectRepository.php
@@ -185,6 +185,7 @@ class ProjectRepository implements ProjectInterface{
 			{
 				$projectcollabs = new ProjectUsers;
 				$projectcollabs->user_id = $userId;
+                $projectcollabs->updated_by = $userId;
 				$projectcollabs->project_id = $projectId;
 				$projectcollabs->save();	
 								


### PR DESCRIPTION
Fixing issue of NOT NULL 'updated_by' field not being set in new project creation
