### PR TITLE
Update style.css to fix no scroll project dropdown in task view

### DIFF
--- a/assets/css/dashboard/style.css
+++ b/assets/css/dashboard/style.css
@@ -1160,7 +1160,7 @@ ul.task_list li a:hover{ text-decoration:none; color:#000000;}
    cursor: default;
     /* Hiding */
     max-height: 0;
-    overflow: hidden;
+    overflow: scroll;
 }
 .wrapper-demo{
 	float: left;


### PR DESCRIPTION
I noticed that the dropdown overflow was set to hidden. Jay McCaul had the same issue here --> http://forums.92fiveapp.com/?p=53-tasks-view-project-filter-drop-down

I've proposed changing line 1163 from 
overflow: hidden; 
to 
overflow: scroll;