### PR TITLE
Date-processing bug in ProjectRepository

### DIFF
--- a/app/ninetwofive/project/ProjectRepository.php
+++ b/app/ninetwofive/project/ProjectRepository.php
@@ -384,41 +384,32 @@ class ProjectRepository implements ProjectInterface{
 	* Delete project
 	*/
 	public function deleteProject($projectId,$userId)
-	{
-		//Get the task Ids of the project
-		$tasks = \Task::where('project_id',$projectId)->lists('id');
-		if($tasks == null)
-		{
-			//No Tasks. Delete data and users from the database
-			$projectUsers = ProjectUsers::where('project_id',$projectId)->delete();
-			$project = Project::find($projectId);
-			$project->deleted_by = $userId;
-			$project->save();
-			$project->delete();
-			return true;
-		}
-		else
-		{
-			//Delete all users and data for all tasks of the project. Also delete all the users and data for the project
-			$projectUsers = ProjectUsers::where('project_id',$projectId)->delete();
-			$taskUsers = TaskUser::whereIn('task_id',$tasks)->delete();
-			//$tasks = Task::where('project_id',$projectId)->delete();
-			foreach($tasks as $taskId)
-			{
-				$task = \Task::find($taskId);
-				$task->deleted_by = $userId;
-				$task->save();
-				$task->delete();
-			}
-
-			$project = Project::find($projectId);
-			$project->deleted_by = $userId;
-			$project->save();
-			$project->delete();
-			return true;
-		}
-
-	}
+    {
+        $project = Project::find($projectId);
+        if(null == $project) {
+            return false;
+        }
+        //Get the task Ids of the project
+        $tasks = \Task::where('project_id',$projectId)->lists('id');
+        if(null != $tasks) {
+            //Delete all users and data for all tasks of the project. Also delete all the users and data for the project
+            $projectUsers = ProjectUsers::where('project_id', $projectId)->delete();
+            $taskUsers = TaskUser::whereIn('task_id', $tasks)->delete();
+            foreach ($tasks as $taskId) {
+                $task = \Task::find($taskId);
+                $task->deleted_by = $userId;
+                $task->save();
+                $task->delete();
+            }
+        } else {
+            //No Tasks. Delete data and users from the database
+            $projectUsers = ProjectUsers::where('project_id', $projectId)->delete();
+        }
+        $project->deleted_by = $userId;
+        $project->save();
+        $project->delete();
+        return true;
+    }
 
     /*
      * Handle string input for start/end date generation

--- a/app/tests/ProjectRepositoryTest.php
+++ b/app/tests/ProjectRepositoryTest.php
@@ -221,4 +221,32 @@ class ProjectRepositoryTest extends \TestCase
 
         $result = $repo->updateProject($data, $alice->id);
     }
+
+    public function testProcessDateStringKnownGoodData()
+    {
+        $repo = new ProjectRepository();
+        $result = $repo->processDateString('20 July, 2016');
+        $this->assertEquals('2016-07-20', $result);
+    }
+
+    public function testProcessDateStringShouldBeGoodData()
+    {
+        $repo = new ProjectRepository();
+        $result = $repo->processDateString('20 July, 2016 at 12:00 am');
+        $this->assertEquals('2016-07-20', $result);
+    }
+
+    public function testProcessDateStringKnownBadData()
+    {
+        $repo = new ProjectRepository();
+        $result = $repo->processDateString('2016-07-20');
+        $this->assertEquals(null, $result);
+    }
+
+    public function testProcessDateStringNullData()
+    {
+        $repo = new ProjectRepository();
+        $result = $repo->processDateString(null);
+        $this->assertEquals(null, $result);
+    }
 }

--- a/app/tests/ProjectRepositoryTest.php
+++ b/app/tests/ProjectRepositoryTest.php
@@ -1,0 +1,224 @@
+<?php
+
+class ProjectRepositoryTest extends \TestCase
+{
+    public function testAddProjectGoodDates()
+    {
+        // dig out group to assign
+        $group = Sentry::findGroupByName('admin');
+
+        // set up sample users
+        $aliceCredentials = array(
+            'first_name' => 'Alice',
+            'last_name' => 'Example',
+            'email' => 'alice@example.com',
+            'password' => 'bruceschneier',
+            'activated' => true,
+        );
+        $bobCredentials = array(
+            'first_name' => 'Bob',
+            'last_name' => 'Demonstration',
+            'email' => 'bob@demonstration.net',
+            'password' => 'oursharedsecret',
+            'activated' => true,
+        );
+
+        $alice = Sentry::createUser($aliceCredentials);
+        $bob = Sentry::createUser($bobCredentials);
+
+        $alice->addGroup($group);
+        $bob->addGroup($group);
+
+        $data = array (
+            'project_name' => 'Das Testprojekt',
+            'description' => '',
+            'note' => '',
+            'startdate' => "20 July, 2016",
+            'enddate' => "20 July, 2017",
+            'project_client' => 'Test',
+            'tagsinput' => 'alice@example.com,bob@demonstration.net'
+        );
+
+        $repo = new ProjectRepository();
+
+        $result = $repo->addProject($data, $bob->id);
+        $project = \Project::where('project_name',$data['project_name'])->first();
+        // start checking what came out
+        $this->assertEquals($data['project_name'], $project->project_name);
+        $this->assertEquals($data['project_client'], $project->project_client);
+        $this->assertEquals("2016-07-20", $project->start_date);
+        $this->assertEquals("2017-07-20", $project->end_date);
+
+        $this->assertEquals($project->id, $result['projectId']);
+        $this->assertEquals($data['project_name'], $result['project_name']);
+    }
+
+    public function testAddProjectBadDates()
+    {
+        // dig out group to assign
+        $group = Sentry::findGroupByName('admin');
+
+        // set up sample users
+        $aliceCredentials = array(
+            'first_name' => 'Alice',
+            'last_name' => 'Example',
+            'email' => 'alice@example.com',
+            'password' => 'bruceschneier',
+            'activated' => true,
+        );
+        $bobCredentials = array(
+            'first_name' => 'Bob',
+            'last_name' => 'Demonstration',
+            'email' => 'bob@demonstration.net',
+            'password' => 'oursharedsecret',
+            'activated' => true,
+        );
+
+        $alice = Sentry::createUser($aliceCredentials);
+        $bob = Sentry::createUser($bobCredentials);
+
+        $alice->addGroup($group);
+        $bob->addGroup($group);
+
+        $data = array (
+            'project_name' => 'Das Testprojekt',
+            'description' => '',
+            'note' => '',
+            'startdate' => "2016-07-20",
+            'enddate' => "2017-07-20",
+            'project_client' => 'Test',
+            'tagsinput' => 'alice@example.com,bob@demonstration.net'
+        );
+
+        $repo = new ProjectRepository();
+
+        $result = $repo->addProject($data, $bob->id);
+        $project = \Project::where('project_name',$data['project_name'])->first();
+        $collabs = $project->projectcollabs()->get();
+        // start checking what came out
+        $this->assertEquals($data['project_name'], $project->project_name);
+        $this->assertEquals($data['project_client'], $project->project_client);
+        $this->assertEquals(null, $project->start_date);
+        $this->assertEquals(null, $project->end_date);
+
+        $this->assertEquals($project->id, $result['projectId']);
+        $this->assertEquals($data['project_name'], $result['project_name']);
+        $this->assertEquals(2, $collabs->count());
+        $this->assertEquals($alice->id, $collabs[0]->id);
+        $this->assertEquals($bob->id, $collabs[1]->id);
+    }
+
+    public function testUpdateProjectWithAsSuppliedDatesAndTimes()
+    {
+        // dig out group to assign
+        $group = Sentry::findGroupByName('admin');
+
+        // set up sample users
+        $aliceCredentials = array(
+            'first_name' => 'Alice',
+            'last_name' => 'Example',
+            'email' => 'alice@example.com',
+            'password' => 'bruceschneier',
+            'activated' => true,
+        );
+        $bobCredentials = array(
+            'first_name' => 'Bob',
+            'last_name' => 'Demonstration',
+            'email' => 'bob@demonstration.net',
+            'password' => 'oursharedsecret',
+            'activated' => true,
+        );
+
+        $alice = Sentry::createUser($aliceCredentials);
+        $bob = Sentry::createUser($bobCredentials);
+
+        $alice->addGroup($group);
+        $bob->addGroup($group);
+
+        $data = array (
+            'project_name' => 'Das Testprojekt',
+            'description' => '',
+            'note' => '',
+            'startdate' => "2016-07-20",
+            'enddate' => "2017-07-20",
+            'project_client' => 'Test',
+            'tagsinput' => 'alice@example.com,bob@demonstration.net'
+        );
+
+        $repo = new ProjectRepository();
+
+        $result = $repo->addProject($data, $bob->id);
+        $project = \Project::where('project_name',$data['project_name'])->first();
+
+        $data = array (
+            'projectid' => $project->id,
+            'project_name' => 'Das Testprojekt',
+            'description' => '',
+            'note' => '',
+            'startdate' => "20th July, 2016 at 12:00am",
+            'enddate' => "20th July, 2017 at 12:00am",
+            'project_client' => 'Test',
+            'tagsinput' => 'alice@example.com,bob@demonstration.net',
+            'status' => 'active'
+        );
+
+        $result = $repo->updateProject($data, $alice->id);
+    }
+
+    public function testUpdateProjectWithKnownGoodDatesAndTimes()
+    {
+        // dig out group to assign
+        $group = Sentry::findGroupByName('admin');
+
+        // set up sample users
+        $aliceCredentials = array(
+            'first_name' => 'Alice',
+            'last_name' => 'Example',
+            'email' => 'alice@example.com',
+            'password' => 'bruceschneier',
+            'activated' => true,
+        );
+        $bobCredentials = array(
+            'first_name' => 'Bob',
+            'last_name' => 'Demonstration',
+            'email' => 'bob@demonstration.net',
+            'password' => 'oursharedsecret',
+            'activated' => true,
+        );
+
+        $alice = Sentry::createUser($aliceCredentials);
+        $bob = Sentry::createUser($bobCredentials);
+
+        $alice->addGroup($group);
+        $bob->addGroup($group);
+
+        $data = array (
+            'project_name' => 'Das Testprojekt',
+            'description' => '',
+            'note' => '',
+            'startdate' => "2016-07-20",
+            'enddate' => "2017-07-20",
+            'project_client' => 'Test',
+            'tagsinput' => 'alice@example.com,bob@demonstration.net'
+        );
+
+        $repo = new ProjectRepository();
+
+        $result = $repo->addProject($data, $bob->id);
+        $project = \Project::where('project_name',$data['project_name'])->first();
+
+        $data = array (
+            'projectid' => $project->id,
+            'project_name' => 'Das Testprojekt',
+            'description' => '',
+            'note' => '',
+            'startdate' => "20 July, 2016",
+            'enddate' => "20 July, 2017",
+            'project_client' => 'Test',
+            'tagsinput' => 'alice@example.com,bob@demonstration.net',
+            'status' => 'active',
+        );
+
+        $result = $repo->updateProject($data, $alice->id);
+    }
+}


### PR DESCRIPTION
The bug I tripped over here (similar to #106) was that, when updating a given calendar entry, the code assumed that DateTime::createFromFormat always succeeded - it didn't handle when it failed and returned FALSE.

I also tripped over (and fixed) a small bug in ProjectRepository->EditProject where updated_by wasn't being set on project collaborators.